### PR TITLE
Pass jsonQueryFormat and jsonCallback to event.renderData in default …

### DIFF
--- a/handlers/BaseHandler.cfc
+++ b/handlers/BaseHandler.cfc
@@ -120,7 +120,9 @@ component extends="coldbox.system.EventHandler"{
 			statusCode 	= prc.response.getStatusCode(),
 			statusText 	= prc.response.getStatusText(),
 			location 	= prc.response.getLocation(),
-			isBinary 	= prc.response.getBinary()
+			isBinary 	= prc.response.getBinary(),
+			jsonCallback 	= prc.response.getJsonCallback(),
+			jsonQueryFormat	= prc.response.getJsonQueryFormat()
 		);
 		
 		// Global Response Headers

--- a/models/Response.cfc
+++ b/models/Response.cfc
@@ -14,7 +14,7 @@ component accessors="true"{
 	property name="messages" 		type="array";
 	property name="location" 		type="string"		default="";
 	property name="jsonCallback" 	type="string"		default="";
-	property name="jsonQueryFormat" type="string"		default="query";
+	property name="jsonQueryFormat" type="string"		default="true" hint="JSON Only: This parameter can be a Boolean value that specifies how to serialize ColdFusion queries or a string with possible values row, column, or struct";
 	property name="contentType" 	type="string"		default="";
 	property name="statusCode" 		type="numeric"		default="200";
 	property name="statusText" 		type="string"		default="OK";


### PR DESCRIPTION
https://ortussolutions.atlassian.net/browse/COLDBOX-674

Have BasseHandler pass jsonCallback and jsonQueryFormat to renderData()

Change jsonQueryFormat default to "true" and add hint from DataMarshaller explaining why it's a frankenBooleanString